### PR TITLE
Adds new integration [figorr/meteocat]

### DIFF
--- a/integration
+++ b/integration
@@ -347,6 +347,7 @@
   "fapfaff/homeassistant-appwash",
   "faserf/ha-deutschebahn",
   "faserf/ha-rewe",
+  "figorr/meteocat",
   "filipvh/hass-nhc2",
   "fineemb/Colorfulclouds-weather",
   "fineemb/Smartmi-smart-heater",


### PR DESCRIPTION
This PR adds the Meteocat custom integration to HACS under the integrations category. It has passed Hassfest and HACS validation tests.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/figorr/meteocat/releases/tag/v1.0.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/figorr/meteocat/actions/runs/12618621265/job/35163043473>
Link to successful hassfest action (if integration): <https://github.com/figorr/meteocat/actions/runs/12618621264/job/35163061523>

